### PR TITLE
fix: unsafe block was missed

### DIFF
--- a/hil-test/tests/aes.rs
+++ b/hil-test/tests/aes.rs
@@ -566,7 +566,7 @@ mod tests {
         let signal = mk_static!(Signal<CriticalSectionRawMutex, ()>, Signal::new());
 
         // Start task before we'd start the AES operation
-        let spawner = Spawner::for_current_executor().await;
+        let spawner = unsafe { Spawner::for_current_executor().await };
         spawner.must_spawn(aes_task(signal));
 
         signal.wait().await;


### PR DESCRIPTION
# Missed unsafe block

Hi tests were failing I think from what I saw was due to this missing unsafe block
